### PR TITLE
Allow unrecognised `role`s of `ManifestChildren`

### DIFF
--- a/lib/Model/ManifestChildren.php
+++ b/lib/Model/ManifestChildren.php
@@ -360,9 +360,9 @@ class ManifestChildren implements ArrayAccess
      */
     public function setRole($role)
     {
-        $allowed_values = array('2d', '3d', 'graphics', 'manifest', 'thumbnail', 'Autodesk.CloudPlatform.PropertyDatabase', 'viewable', 'ifc', 'Autodesk.AEC.ModelData');
+        $allowed_values = array('2d', '3d', 'graphics', 'manifest', 'thumbnail', 'Autodesk.CloudPlatform.PropertyDatabase', 'viewable', 'ifc', 'Autodesk.AEC.ModelData', 'pdf-page');
         if ((!in_array($role, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail', 'Autodesk.CloudPlatform.PropertyDatabase', 'viewable', 'ifc', 'Autodesk.AEC.ModelData'");
+            trigger_error("Invalid value for 'role', must be one of '2d', '3d', 'graphics', 'manifest', 'thumbnail', 'Autodesk.CloudPlatform.PropertyDatabase', 'viewable', 'ifc', 'Autodesk.AEC.ModelData', 'pdf-page'", E_USER_WARNING);
         }
         $this->container['role'] = $role;
 


### PR DESCRIPTION
This SDK is outdated so it throws exceptions on unrecognised values.

For `role` in `ManifestChildren` make it so the error does not stop code execution.

Additionally, add `'pdf-page'` as recognised `role` value.